### PR TITLE
feature: 세 개의 추상클래스 RequireMessage, MessageToDisplay, ErrorMessage 를 …

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -153,7 +153,7 @@ sequenceDiagram
     - CarNamesRequireInputMessage: 사용자에게 자동차 이름 입력을 요청하는 메시지
     - NumberOfRoundRequireInputMessage: 사용자에게 시도할 횟수 입력을 요청하는 메시지
   - MessageToDisplay (추상클래스)
-    - StartOfRacingMessageToDisplay: 게임 시작할 때 "실행 결과" 라고 한 줄 출력하는 메시지
+    - StartOfRaceMessageToDisplay: 게임 시작할 때 "실행 결과" 라고 한 줄 출력하는 메시지
     - CurrentRaceResultMessageToDisplay: 현재까지 자동차 경주 결과를 출력하는 메시지
     - FinalWinnerMessageToDisplay: 최종 우승자를 출력하는 메시지
   - ErrorMessage (추상클래스)

--- a/src/main/java/racingcar/view/error/message/CarNamesErrorMessage.java
+++ b/src/main/java/racingcar/view/error/message/CarNamesErrorMessage.java
@@ -1,0 +1,7 @@
+package racingcar.view.error.message;
+
+public class CarNamesErrorMessage extends ErrorMessage {
+    public CarNamesErrorMessage(String value) {
+        super(value);
+    }
+}

--- a/src/main/java/racingcar/view/error/message/ErrorMessage.java
+++ b/src/main/java/racingcar/view/error/message/ErrorMessage.java
@@ -5,7 +5,7 @@ import racingcar.view.Message;
 public class ErrorMessage implements Message {
     protected String value;
 
-    public ErrorMessage(String value) {
+    protected ErrorMessage(String value) {
         this.value = value;
     }
 

--- a/src/main/java/racingcar/view/error/message/NumberOfRoundErrorMessage.java
+++ b/src/main/java/racingcar/view/error/message/NumberOfRoundErrorMessage.java
@@ -1,0 +1,7 @@
+package racingcar.view.error.message;
+
+public class NumberOfRoundErrorMessage extends ErrorMessage {
+    public NumberOfRoundErrorMessage(String value) {
+        super(value);
+    }
+}

--- a/src/main/java/racingcar/view/message/to/display/CurrentRaceResultMessageToDisplay.java
+++ b/src/main/java/racingcar/view/message/to/display/CurrentRaceResultMessageToDisplay.java
@@ -1,0 +1,7 @@
+package racingcar.view.message.to.display;
+
+public class CurrentRaceResultMessageToDisplay extends MessageToDisplay {
+    public CurrentRaceResultMessageToDisplay(String value) {
+        super(value);
+    }
+}

--- a/src/main/java/racingcar/view/message/to/display/FinalWinnerMessageToDisplay.java
+++ b/src/main/java/racingcar/view/message/to/display/FinalWinnerMessageToDisplay.java
@@ -1,0 +1,7 @@
+package racingcar.view.message.to.display;
+
+public class FinalWinnerMessageToDisplay extends MessageToDisplay {
+    public FinalWinnerMessageToDisplay(String value) {
+        super(value);
+    }
+}

--- a/src/main/java/racingcar/view/message/to/display/MessageToDisplay.java
+++ b/src/main/java/racingcar/view/message/to/display/MessageToDisplay.java
@@ -5,7 +5,7 @@ import racingcar.view.Message;
 public class MessageToDisplay implements Message {
     protected String value;
 
-    public MessageToDisplay(String value) {
+    protected MessageToDisplay(String value) {
         this.value = value;
     }
 

--- a/src/main/java/racingcar/view/message/to/display/StartOfRaceMessageToDisplay.java
+++ b/src/main/java/racingcar/view/message/to/display/StartOfRaceMessageToDisplay.java
@@ -1,0 +1,7 @@
+package racingcar.view.message.to.display;
+
+public class StartOfRaceMessageToDisplay extends MessageToDisplay {
+    public StartOfRaceMessageToDisplay(String value) {
+        super(value);
+    }
+}

--- a/src/main/java/racingcar/view/require/message/CarNamesRequireInputMessage.java
+++ b/src/main/java/racingcar/view/require/message/CarNamesRequireInputMessage.java
@@ -1,0 +1,7 @@
+package racingcar.view.require.message;
+
+public class CarNamesRequireInputMessage extends RequireMessage {
+    public CarNamesRequireInputMessage(String value) {
+        super(value);
+    }
+}

--- a/src/main/java/racingcar/view/require/message/NumberOfRoundRequireInputMessage.java
+++ b/src/main/java/racingcar/view/require/message/NumberOfRoundRequireInputMessage.java
@@ -1,0 +1,7 @@
+package racingcar.view.require.message;
+
+public class NumberOfRoundRequireInputMessage extends RequireMessage {
+    public NumberOfRoundRequireInputMessage(String value) {
+        super(value);
+    }
+}

--- a/src/main/java/racingcar/view/require/message/RequireMessage.java
+++ b/src/main/java/racingcar/view/require/message/RequireMessage.java
@@ -5,7 +5,7 @@ import racingcar.view.Message;
 public class RequireMessage implements Message {
     protected String value;
 
-    public RequireMessage(String value) {
+    protected RequireMessage(String value) {
         this.value = value;
     }
 


### PR DESCRIPTION
…상속하는 구체 클래스 구현 (#7)

추상클래스 RequireMessage 상속하는 구체클래스는 CarNamesRequireInputMessage, NumberOfRoundRequireInputMessage 이고 추상클래스 MessageToDisplay 상속하는 구체클래스는 StartOfRacingMessageToDisplay, CurrentRaceResultMessageToDisplay, FinalWinnerMessageToDisplay 이고 추상클래스 ErrorMessage 상속하는 구체클래스는 CarNamesErrorMessage, NumberOfRoundErrorMessage 이다

관련 일감
[feature: 세 개의 추상클래스 RequireMessage, MessageToDisplay, ErrorMessage 를 상속하는 구체 클래스 구현](https://github.com/OptimistLabyrinth/java-racingcar-precourse/issues/7)