### PR TITLE
feature: CarNamesErrorMessage 내부 로직 구현

### DIFF
--- a/src/main/java/racingcar/view/error/message/CarNamesErrorMessage.java
+++ b/src/main/java/racingcar/view/error/message/CarNamesErrorMessage.java
@@ -2,7 +2,7 @@ package racingcar.view.error.message;
 
 public class CarNamesErrorMessage extends ErrorMessage {
     public CarNamesErrorMessage(String value) {
-        super(value);
+        super("[ERROR] 자동차 이름을 다시 입력해주세요.");
     }
 
     @Override


### PR DESCRIPTION
사용자가 자동차 이름 입력하는 과정에서 IllegalArgumentException 발생시키는 경우
```[ERROR]```로 시작하는 오류 메시지를 출력한다.

관련 일감
[CarNamesErrorMessage 내부 로직 구현](https://github.com/OptimistLabyrinth/java-racingcar-precourse/issues/70)